### PR TITLE
use requirements.txt in build-pyplanet dockerfile

### DIFF
--- a/build-pyplanet/Dockerfile
+++ b/build-pyplanet/Dockerfile
@@ -19,8 +19,8 @@ RUN chmod +x *.sh
 
 # install pyplanet
 ENV PATH="${PATH}:/home/server/.local/bin"
-RUN pip3 install --user -r $PYPLANET_HOME/requirements.txt
 ADD pyplanet $PYPLANET_HOME
+RUN pip3 install --user -r $PYPLANET_HOME/requirements.txt
 RUN mkdir $PYPLANET_HOME/tmp && mkdir $PYPLANET_HOME/logs
 
 # docs: https://pypla.net/en/latest/intro/configuration.html

--- a/build-pyplanet/Dockerfile
+++ b/build-pyplanet/Dockerfile
@@ -19,7 +19,7 @@ RUN chmod +x *.sh
 
 # install pyplanet
 ENV PATH="${PATH}:/home/server/.local/bin"
-RUN pip3 install --user pyplanet
+RUN pip3 install --user -r $PYPLANET_HOME/requirements.txt
 ADD pyplanet $PYPLANET_HOME
 RUN mkdir $PYPLANET_HOME/tmp && mkdir $PYPLANET_HOME/logs
 


### PR DESCRIPTION
I noticed that the pyplanet dockerfile does not use the provided requirements.txt

Closes #1 